### PR TITLE
Add preparation checks to context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withfabric/protocol-sdks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SDKs for Fabric EVM Protocols",
   "author": "Fabric Inc.",
   "license": "ISC",

--- a/src/cfpv1/context.test.ts
+++ b/src/cfpv1/context.test.ts
@@ -49,9 +49,12 @@ describe('context API', () => {
       expect(approvalReceipt.status).toEqual('success');
     }
 
+    expect(context.isContributionPrepared()).toEqual(false);
     await context.prepareContribution(contribution);
+    expect(context.isContributionPrepared()).toEqual(true);
     const contributionReceipt = await context.executeContribution();
     expect(contributionReceipt.status).toEqual('success');
+    expect(context.isContributionPrepared()).toEqual(false);
 
     // Refresh context to ensure new state is reflected
     context = await context.refresh();
@@ -65,20 +68,29 @@ describe('context API', () => {
     const yieldAmount = 420n;
 
     if (context.isTokenApprovalRequired(yieldAmount)) {
+      expect(context.isApprovalPrepared()).toEqual(false);
       await context.prepareTokenApproval(yieldAmount);
+      expect(context.isApprovalPrepared()).toEqual(true);
       const yieldApprovalReceipt = await context.executeTokenApproval();
       expect(yieldApprovalReceipt.status).toEqual('success');
+      expect(context.isApprovalPrepared()).toEqual(false);
     }
 
     context = await context.refresh();
 
+    expect(context.isYieldPrepared()).toEqual(false);
     await context.prepareYield(yieldAmount);
+    expect(context.isYieldPrepared()).toEqual(true);
     const yieldReceipt = await context.executeYield();
     expect(yieldReceipt.status).toEqual('success');
+    expect(context.isYieldPrepared()).toEqual(false);
 
     // do withdraw
+    expect(context.isWithdrawPrepared()).toEqual(false);
     await context.prepareWithdraw();
+    expect(context.isWithdrawPrepared()).toEqual(true);
     const withdrawReceipt = await context.executeWithdraw();
     expect(withdrawReceipt.status).toEqual('success');
+    expect(context.isWithdrawPrepared()).toEqual(false);
   });
 });

--- a/src/cfpv1/context.ts
+++ b/src/cfpv1/context.ts
@@ -213,6 +213,14 @@ export class CampaignAccountContext {
   }
 
   /**
+   * @description Check if a token approval transaction is prepared
+   * @returns true if a token approval transaction is prepared
+   */
+  isApprovalPrepared() : boolean {
+    return this.approveTxn !== undefined;
+  }
+
+  /**
    * @description Execute the prepared token approval transaction
    * @returns The transaction receipt
    */
@@ -243,6 +251,14 @@ export class CampaignAccountContext {
   }
 
   /**
+   * @description Check if a contribution transaction is prepared
+   * @returns true if a contribution transaction is prepared
+   */
+  isContributionPrepared() : boolean {
+    return this.contributeTxn !== undefined;
+  }
+
+  /**
    * @description Execute the prepared contribution transaction
    * @returns The transaction receipt
    */
@@ -267,6 +283,14 @@ export class CampaignAccountContext {
     this.transferTxn = await prepareCampaignFundsTransfer({
       campaignAddress: this.state.address,
     });
+  }
+
+  /**
+   * @description Check if a transfer transaction is prepared
+   * @returns true if a transfer transaction is prepared
+   */
+  isTransferPrepared() : boolean {
+    return this.transferTxn !== undefined;
   }
 
   /**
@@ -300,6 +324,14 @@ export class CampaignAccountContext {
   }
 
   /**
+   * @description Check if a yield transaction is prepared
+   * @returns true if a yield transaction is prepared
+   */
+  isYieldPrepared() : boolean {
+    return this.yieldTxn !== undefined;
+  }
+
+  /**
    * @description Execute the prepared yield transaction
    * @returns The transaction receipt
    */
@@ -324,6 +356,14 @@ export class CampaignAccountContext {
     this.withdrawTxn = await prepareCampaignWithdraw({
       campaignAddress: this.state.address,
     });
+  }
+
+  /**
+   * @description Check if a withdraw transaction is prepared
+   * @returns true if a withdraw transaction is prepared
+   */
+  isWithdrawPrepared() : boolean {
+    return this.withdrawTxn !== undefined;
   }
 
   /**


### PR DESCRIPTION
When using context in web apps, it makes sense to defer execution until user click, but there is no way to check that the transaction is prepared. These helpers can assist in situations where error handling doesn't block advancement.

Also added more examples.